### PR TITLE
Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.sw[op]
+*~
+.cproject
+.project
+.c9
+*.sublime-project
+*.sublime-workspace
+.DS_Store
+.settings
+coverage
+node_modules
+v8.log
+.c9revisions
+npm-debug.log
+package-lock.json
+.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .c9
 *.sublime-project
 *.sublime-workspace
+.vscode
 .DS_Store
 .settings
 coverage

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
  */
 
 module.exports = function(config) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+
+module.exports = function(config) {
+  config.set({
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'tests/*.spec.js'
+    ],
+
+    // list of files to exclude
+    exclude: ['bin/*'],
+    preprocessors: {
+      'tests/*.js': ['webpack', 'sourcemap']
+    },
+
+    webpack: {
+      //mode: 'production',
+      mode: 'development',
+      devtool: 'inline-source-map',
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            exclude: [
+              /bin/,
+              /node_modules\/(?!jsonld|crypto-ld)/
+            ],
+            use: {
+              loader: 'babel-loader',
+              options: {
+                presets: ['@babel/preset-env'],
+                plugins: [
+                  '@babel/plugin-transform-modules-commonjs',
+                  '@babel/plugin-transform-runtime',
+                  '@babel/plugin-proposal-object-rest-spread'
+                ]
+              }
+            }
+          }
+        ]
+      },
+      node: {
+        Buffer: false,
+        process: false,
+        crypto: false,
+        setImmediate: false
+      },
+      externals: {
+        'bitcore-message': '\'bitcore-message\''
+      }
+    },
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    //reporters: ['progress'],
+    reporters: ['mocha'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR ||
+    //   config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any
+    // file changes
+    autoWatch: false,
+
+    // start these browsers
+    // browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    //browsers: ['ChromeHeadless', 'Chrome', 'Firefox', 'Safari'],
+    browsers: ['ChromeHeadless'],
+
+    customLaunchers: {
+      IE9: {
+        base: 'IE',
+        'x-ua-compatible': 'IE=EmulateIE9'
+      },
+      IE8: {
+        base: 'IE',
+        'x-ua-compatible': 'IE=EmulateIE8'
+      }
+    },
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+  });
+};

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -11,6 +11,22 @@ import {createAuthzHeader, createSignatureString} from 'http-signature-header';
 // detect browser environment
 const isBrowser = (typeof self !== 'undefined');
 
+/**
+ * Signs an HTTP message with a capability.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.url - The invocation target.
+ * @param {string} options.method - An HTTP method.
+ * @param {object} options.headers - The headers in the HTTP message.
+ * @param {object} options.json - A json object.
+ * @param {string|object} options.capability - Either a string or a capability
+ *   object.
+ * @param {object} options.invocationSigner - The invokver's key for signing.
+ * @param {string|array} options.capabilityAction - The action(s) the capability
+ *   can perform.
+ *
+ * @returns {object} The signed headers.
+ */
 export async function signCapabilityInvocation({
   url, method, headers, json, capability = url, invocationSigner,
   capabilityAction

--- a/main.js
+++ b/main.js
@@ -6,11 +6,7 @@
 import base64url from 'base64url-universal';
 import crypto from './crypto.js';
 import {TextEncoder, URL, base64Encode} from './util.js';
-import {
-  HttpSignatureError,
-  createAuthzHeader,
-  createSignatureString
-} from 'http-signature-header';
+import {createAuthzHeader, createSignatureString} from 'http-signature-header';
 
 // detect browser environment
 const isBrowser = (typeof self !== 'undefined');
@@ -26,7 +22,7 @@ const isBrowser = (typeof self !== 'undefined');
  * @param {string|object} options.capability - Either a string or a capability
  *   object.
  * @param {object} options.invocationSigner - The invoker's key for signing.
- * @param {string|array} options.capabilityAction - The action(s) the capability
+ * @param {string} options.capabilityAction - The action(s) the capability
  *   can perform.
  *
  * @returns {object} The signed headers.
@@ -37,13 +33,15 @@ export async function signCapabilityInvocation({
 }) {
   // we must have an invocationSigner
   if(!invocationSigner) {
-    throw new HttpSignatureError(
-      'invocationSigner required', 'ConstraintError');
+    throw new SyntaxError('invocationSigner required');
   }
   // the invocationSigner must have a .sign method
   if(!invocationSigner.sign) {
-    throw new HttpSignatureError(
-      'invocationSigner must have a sign method', 'DataError');
+    throw new TypeError('invocationSigner must have a sign method');
+  }
+  // the invocationSigner must have a .sign method
+  if(typeof(invocationSigner.sign) !== 'function') {
+    throw new TypeError('invocationSigner must have a sign method');
   }
   // lower case keys to ensure any updates apply properly
   const signed = _lowerCaseObjectKeys(headers);
@@ -58,7 +56,7 @@ export async function signCapabilityInvocation({
   }
   // a zCap must have a capability.
   if(!capability) {
-    throw new HttpSignatureError('capability is undefined', 'ConstraintError');
+    throw new TypeError('capability must be a string, object, or url');
   }
   let invocationHeader = `zcap id="${capability}"`;
   if(capabilityAction) {

--- a/main.js
+++ b/main.js
@@ -31,6 +31,9 @@ export async function signCapabilityInvocation({
   url, method, headers, json, capability = url, invocationSigner,
   capabilityAction
 }) {
+  if(!invocationSigner) {
+    throw new Error('invocationSigner required');
+  }
   // lower case keys to ensure any updates apply properly
   const signed = _lowerCaseObjectKeys(headers);
 
@@ -70,16 +73,6 @@ export async function signCapabilityInvocation({
   // set expiration 10 minutes into the future
   const created = Date.now();
   const expires = new Date(created + 600000).getTime();
-
-  // FIXME: remove me
-  if(!invocationSigner) {
-    invocationSigner = {
-      id: 'did:key:z6MkhC8JS6vN9AQDww5sKaZAhpwoC3WWwvdsoprzAkzo1beC',
-      sign() {
-        return new Uint8Array([0x01, 0x02, 0x03]);
-      }
-    };
-  }
 
   // sign header
   const {id: keyId} = invocationSigner;

--- a/main.js
+++ b/main.js
@@ -12,13 +12,13 @@ import {createAuthzHeader, createSignatureString} from 'http-signature-header';
 const isBrowser = (typeof self !== 'undefined');
 
 /**
- * Signs an HTTP message with a capability.
+ * Signs an HTTP message to invoke a capability.
  *
  * @param {object} options - Options to use.
  * @param {string} options.url - The invocation target.
  * @param {string} options.method - An HTTP method.
  * @param {object} options.headers - The headers in the HTTP message.
- * @param {object} options.json - A json object.
+ * @param {object} [options.json] - An optional json object representing an HTTP JSON body, if any.
  * @param {string|object} options.capability - Either a string or a capability
  *   object.
  * @param {object} options.invocationSigner - The invoker's key for signing.
@@ -33,14 +33,14 @@ export async function signCapabilityInvocation({
 }) {
   // we must have an invocationSigner
   if(!invocationSigner) {
-    throw new SyntaxError('invocationSigner required');
+    throw new TypeError('"invocationSigner" must be an object.');
   }
   // the invocationSigner must have a .sign method
   if(!invocationSigner.sign) {
-    throw new TypeError('invocationSigner must have a sign method');
+    throw new TypeError('"invocationSigner.sign" must be a function.');
   }
   // the invocationSigner must have a .sign method
-  if(typeof(invocationSigner.sign) !== 'function') {
+  if(typeof invocationSigner.sign !== 'function') {
     throw new TypeError('invocationSigner must have a sign method');
   }
   // lower case keys to ensure any updates apply properly
@@ -56,7 +56,7 @@ export async function signCapabilityInvocation({
   }
   // a zCap must have a capability.
   if(!capability) {
-    throw new TypeError('capability must be a string, object, or url');
+    throw new TypeError('"capability" must be a string or an object.');
   }
   let invocationHeader = `zcap id="${capability}"`;
   if(capabilityAction) {

--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ export async function signCapabilityInvocation({
   if(typeof capability === 'object') {
     capability = capability.id;
   }
-  // a zCap must have  capability.
+  // a zCap must have a capability.
   if(!capability) {
     throw new HttpSignatureError('capability is undefined', 'ConstraintError');
   }

--- a/main.js
+++ b/main.js
@@ -6,7 +6,11 @@
 import base64url from 'base64url-universal';
 import crypto from './crypto.js';
 import {TextEncoder, URL, base64Encode} from './util.js';
-import {createAuthzHeader, createSignatureString} from 'http-signature-header';
+import {
+  HttpSignatureError,
+  createAuthzHeader,
+  createSignatureString
+} from 'http-signature-header';
 
 // detect browser environment
 const isBrowser = (typeof self !== 'undefined');
@@ -33,12 +37,13 @@ export async function signCapabilityInvocation({
 }) {
   // we must have an invocationSigner
   if(!invocationSigner) {
-    throw new Error('invocationSigner required');
+    throw new HttpSignatureError(
+      'invocationSigner required', 'ConstraintError');
   }
   // the invocationSigner must have a .sign method
   if(!invocationSigner.sign) {
-    throw new Error('Invalid invocationSigner. invocationSigner must ' +
-      'have a sign method');
+    throw new HttpSignatureError(
+      'invocationSigner must have a sign method', 'DataError');
   }
   // lower case keys to ensure any updates apply properly
   const signed = _lowerCaseObjectKeys(headers);
@@ -53,7 +58,7 @@ export async function signCapabilityInvocation({
   }
   // a zCap must have  capability.
   if(!capability) {
-    throw new Error('capability is undefined');
+    throw new HttpSignatureError('capability is undefined', 'ConstraintError');
   }
   let invocationHeader = `zcap id="${capability}"`;
   if(capabilityAction) {

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ const isBrowser = (typeof self !== 'undefined');
  * @param {object} options.json - A json object.
  * @param {string|object} options.capability - Either a string or a capability
  *   object.
- * @param {object} options.invocationSigner - The invokver's key for signing.
+ * @param {object} options.invocationSigner - The invoker's key for signing.
  * @param {string|array} options.capabilityAction - The action(s) the capability
  *   can perform.
  *

--- a/main.js
+++ b/main.js
@@ -31,8 +31,14 @@ export async function signCapabilityInvocation({
   url, method, headers, json, capability = url, invocationSigner,
   capabilityAction
 }) {
+  // we must have an invocationSigner
   if(!invocationSigner) {
     throw new Error('invocationSigner required');
+  }
+  // the invocationSigner must have a .sign method
+  if(!invocationSigner.sign) {
+    throw new Error('Invalid invocationSigner. invocationSigner must ' +
+      'have a sign method');
   }
   // lower case keys to ensure any updates apply properly
   const signed = _lowerCaseObjectKeys(headers);
@@ -44,6 +50,10 @@ export async function signCapabilityInvocation({
   // build `capability-invocation` header; use ID of capability only
   if(typeof capability === 'object') {
     capability = capability.id;
+  }
+  // a zCap must have  capability.
+  if(!capability) {
+    throw new Error('capability is undefined');
   }
   let invocationHeader = `zcap id="${capability}"`;
   if(capabilityAction) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "crypto-ld": "^3.7.0",
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
+    "http-signature-zcap-verify": "^1.0.2",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chai": "^4.2.0",
     "chai-bytes": "^0.1.2",
     "cross-env": "^5.2.0",
+    "crypto-ld": "^3.7.0",
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
     "karma": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "crypto-ld": "^3.7.0",
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
-    "http-signature-zcap-verify": "^1.0.2",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  env: {mocha: true}
+}

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
+  globals: {
+    should: true
+  },
   env: {mocha: true}
 }

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -315,5 +315,29 @@ describe('signCapabilityInvocation', function() {
       error.message.should.contain('Invalid URL');
     });
 
+    it('a zCap if the capability object has no id', async function() {
+      let result, error = null;
+      try {
+        const invocationSigner = ed25519Key.signer();
+        invocationSigner.id = keyId;
+        result = await signCapabilityInvocation({
+          url: 'https://www.test.org/read/foo',
+          method: 'GET',
+          headers: {
+            keyId,
+            date: new Date().toUTCString()
+          },
+          json: {foo: true},
+          invocationSigner,
+          capability: {}
+        });
+      } catch(e) {
+        error = e;
+      }
+      console.log('result', result);
+      should.not.exist(result);
+      should.exist(error);
+      error.should.be.an.instanceOf(Error);
+    });
   });
 });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -227,11 +227,18 @@ describe('signCapabilityInvocation', function() {
         });
 
         it('a root zCap with out a HTTP method', async function() {
+
+          // detect browser environment
+          const isBrowser = (typeof self !== 'undefined');
+          // this test does not fail in browsers because
+          // assert-plus is disabled in browsers
+          if(isBrowser) {
+            this.skip();
+          }
           let error, result = null;
           try {
             result = await signCapabilityInvocation({
               url: 'https://www.test.org/read/foo',
-              method: undefined,
               headers: {
                 keyId,
                 date: new Date().toUTCString()

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -334,7 +334,6 @@ describe('signCapabilityInvocation', function() {
       } catch(e) {
         error = e;
       }
-      console.log('result', result);
       should.not.exist(result);
       should.exist(error);
       error.should.be.an.instanceOf(Error);

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,6 +1,6 @@
 const {HttpSignatureError} = require('http-signature-header');
 const uuid = require('uuid-random');
-const {signCapabilityInvocation} = require('../index');
+const {signCapabilityInvocation} = require('../main');
 const {Ed25519KeyPair, RSAKeyPair} = require('crypto-ld');
 const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
 
@@ -226,7 +226,7 @@ describe('signCapabilityInvocation', function() {
           invocationSigner.id = `${keyId}:${uuid()}`;
         });
 
-        it('a root zCap with out a method', async function() {
+        it('a root zCap with out a HTTP method', async function() {
           let error, result = null;
           try {
             result = await signCapabilityInvocation({

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -161,11 +161,12 @@ describe('signCapabilityInvocation', function() {
         });
 
         it('a valid root zCap with digest', async function() {
+          const digest = 'f93a541ae8cd64d13d4054abacccb1cb';
           const signed = await signCapabilityInvocation({
             url: 'https://www.test.org/read/foo',
             method: 'GET',
             headers: {
-              digest: 'f93a541ae8cd64d13d4054abacccb1cb',
+              digest,
               keyId,
               date: new Date().toUTCString()
             },
@@ -175,6 +176,7 @@ describe('signCapabilityInvocation', function() {
           shouldBeAnAuthorizedRequest(signed);
           signed.digest.should.exist;
           signed.digest.should.be.a('string');
+          signed.digest.should.equal(digest);
         });
 
         it('a root zCap with out a capabilityAction', async function() {
@@ -231,7 +233,7 @@ describe('signCapabilityInvocation', function() {
           // detect browser environment
           const isBrowser = (typeof self !== 'undefined');
           // this test does not fail in browsers because
-          // assert-plus is disabled in browsers
+          // assert-plus is disabled in browsers in http-signature-header
           if(isBrowser) {
             this.skip();
           }
@@ -274,7 +276,7 @@ describe('signCapabilityInvocation', function() {
           }
           should.not.exist(result);
           should.exist(error);
-          error.should.be.an.instanceOf(Error);
+          error.should.be.an.instanceOf(TypeError);
           error.name.should.contain('TypeError');
           error.message.should.contain(
             'Cannot convert undefined or null to object');

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,0 +1,18 @@
+const {signCapabilityInvocation} = require('../index');
+
+describe('signCapabilityInvocation', function() {
+  it('should sign basic request', async function() {
+    const signed = await signCapabilityInvocation({
+      url: 'https://www.test.org/read/foo',
+      method: 'GET',
+      headers: {date: new Date().toUTCString()},
+      json: {foo: true},
+      invocationSigner: {
+        id: 'did:test:foo',
+        sign() {console.log('signed');}
+      },
+      capabilityAction: 'read'
+    });
+    console.log('signed', signed);
+  });
+});

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -72,6 +72,23 @@ describe('signCapabilityInvocation', function() {
       shouldBeAnAuthorizedRequest(signed);
     });
 
+    it('a root zCap with out a capabilityAction', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capability: 'test'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+    });
+
   });
 
   describe('should NOT sign', function() {
@@ -149,12 +166,29 @@ describe('signCapabilityInvocation', function() {
       error.message.should.contain('invocationSigner');
     });
 
-    it.skip('a root zCap with out a capabilityAction', async function() {
-
-    });
-
-    it.skip('a root zCap with out a url', async function() {
-
+    it('a root zCap with out a url and host', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      let error, result = null;
+      try {
+        result = await signCapabilityInvocation({
+          method: 'post',
+          headers: {
+            keyId,
+            date: new Date().toUTCString()
+          },
+          json: {foo: true},
+          invocationSigner,
+          capabilityAction: 'read'
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.should.be.an.instanceOf(Error);
+      error.name.should.contain('TypeError');
+      error.message.should.contain('Invalid URL');
     });
 
   });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -10,12 +10,12 @@ const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
  * @see https://w3c-ccg.github.io/zcap-ld/
  */
 
-const invocationSignerError = new SyntaxError(
-  'invocationSigner required', 'ConstraintError');
+const invocationSignerError = new TypeError(
+  '"invocationSigner" must be an object.', 'ConstraintError');
 const invocationSignError = new TypeError(
-  'invocationSigner must have a sign method');
+  '"invocationSigner.sign" must be a function.');
 const capabilityError = new TypeError(
-  'capability must be a string, object, or url');
+  '"capability" must be a string or an object.');
 
 // Future Tests can expand this array
 // to test additional LDKeyPairs
@@ -299,7 +299,7 @@ describe('signCapabilityInvocation', function() {
           }
           should.not.exist(result);
           should.exist(error);
-          error.should.be.an.instanceOf(SyntaxError);
+          error.should.be.an.instanceOf(TypeError);
           error.message.should.equal(invocationSignerError.message);
           error.name.should.equal(invocationSignerError.name);
         });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -117,6 +117,28 @@ describe('signCapabilityInvocation', function() {
       signed.digest.should.be.a('string');
     });
 
+    it('a valid root zCap with json', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
+      should.exist(signed['content-type']);
+      signed['content-type'].should.be.a('string');
+      signed['content-type'].should.contain('application/json');
+    });
+
     it('a valid root zCap with out json', async function() {
       const invocationSigner = ed25519Key.signer();
       invocationSigner.id = keyId;

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,18 +1,29 @@
 const {signCapabilityInvocation} = require('../index');
+const {Ed25519KeyPair} = require('crypto-ld');
+const {authorizedRequest} = require('./test-assertions');
 
 describe('signCapabilityInvocation', function() {
+  let ed25519Key, keyId = null;
+  before(async function() {
+    ed25519Key = await Ed25519KeyPair.generate();
+    keyId = 'did:test:foo';
+    ed25519Key.id = keyId;
+  });
   it('should sign basic request', async function() {
+    const invocationSigner = ed25519Key.signer();
+    invocationSigner.id = keyId;
     const signed = await signCapabilityInvocation({
       url: 'https://www.test.org/read/foo',
       method: 'GET',
-      headers: {date: new Date().toUTCString()},
-      json: {foo: true},
-      invocationSigner: {
-        id: 'did:test:foo',
-        sign() {console.log('signed');}
+      headers: {
+        keyId,
+        date: new Date().toUTCString()
       },
+      json: {foo: true},
+      invocationSigner,
       capabilityAction: 'read'
     });
     console.log('signed', signed);
+    authorizedRequest(signed);
   });
 });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -11,7 +11,7 @@ const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
  */
 
 const invocationSignerError = new TypeError(
-  '"invocationSigner" must be an object.', 'ConstraintError');
+  '"invocationSigner" must be an object.');
 const invocationSignError = new TypeError(
   '"invocationSigner.sign" must be a function.');
 const capabilityError = new TypeError(

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,4 +1,3 @@
-const {HttpSignatureError} = require('http-signature-header');
 const uuid = require('uuid-random');
 const {signCapabilityInvocation} = require('../main');
 const {Ed25519KeyPair, RSAKeyPair} = require('crypto-ld');
@@ -11,12 +10,12 @@ const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
  * @see https://w3c-ccg.github.io/zcap-ld/
  */
 
-const invocationSignerError = new HttpSignatureError(
+const invocationSignerError = new SyntaxError(
   'invocationSigner required', 'ConstraintError');
-const invocationSignError = new HttpSignatureError(
-  'invocationSigner must have a sign method', 'DataError');
-const capabilityError = new HttpSignatureError(
-  'capability is undefined', 'ConstraintError');
+const invocationSignError = new TypeError(
+  'invocationSigner must have a sign method');
+const capabilityError = new TypeError(
+  'capability must be a string, object, or url');
 
 // Future Tests can expand this array
 // to test additional LDKeyPairs
@@ -300,7 +299,7 @@ describe('signCapabilityInvocation', function() {
           }
           should.not.exist(result);
           should.exist(error);
-          error.should.be.an.instanceOf(HttpSignatureError);
+          error.should.be.an.instanceOf(SyntaxError);
           error.message.should.equal(invocationSignerError.message);
           error.name.should.equal(invocationSignerError.name);
         });
@@ -327,7 +326,7 @@ describe('signCapabilityInvocation', function() {
             }
             should.not.exist(result);
             should.exist(error);
-            error.should.be.an.instanceOf(HttpSignatureError);
+            error.should.be.an.instanceOf(TypeError);
             error.message.should.equal(invocationSignError.message);
             error.name.should.equal(invocationSignError.name);
           });
@@ -374,7 +373,7 @@ describe('signCapabilityInvocation', function() {
           }
           should.not.exist(result);
           should.exist(error);
-          error.should.be.an.instanceOf(HttpSignatureError);
+          error.should.be.an.instanceOf(TypeError);
           error.message.should.equal(capabilityError.message);
           error.name.should.equal(capabilityError.name);
         });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -14,7 +14,9 @@ describe('signCapabilityInvocation', function() {
     keyId = 'did:key:foo';
     ed25519Key.id = keyId;
   });
+
   describe('should sign', function() {
+
     it('a valid root zCap', async function() {
       const invocationSigner = ed25519Key.signer();
       invocationSigner.id = keyId;
@@ -31,6 +33,7 @@ describe('signCapabilityInvocation', function() {
       });
       shouldBeAnAuthorizedRequest(signed);
     });
+
     it('a valid zCap with a capability string', async function() {
       const invocationSigner = ed25519Key.signer();
       invocationSigner.id = keyId;
@@ -48,8 +51,29 @@ describe('signCapabilityInvocation', function() {
       });
       shouldBeAnAuthorizedRequest(signed);
     });
+
+    it('a valid zCap with a capability object', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capability: {id: 'test'},
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+    });
+
   });
+
   describe('should NOT sign', function() {
+
     it('a root zCap with out a method', async function() {
       const invocationSigner = ed25519Key.signer();
       invocationSigner.id = keyId;
@@ -69,26 +93,43 @@ describe('signCapabilityInvocation', function() {
       } catch(e) {
         error = e;
       }
-      should.exist(error);
-      /**
-       * FIXME this causes mocha to fail the test
-       * with the error signCapabilityInvocation threw.
-      error.should.be.an('object');
-
-      */
       should.not.exist(result);
+      should.exist(error);
+      error.should.be.an.instanceOf(Error);
       error.code.should.exist;
       error.code.should.be.a('string');
+      error.code.should.contain('ERR_ASSERTION');
     });
-    it.skip('a root zCap with out headers', async function() {
 
+    it('a root zCap with out headers', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      let error, result = null;
+      try {
+        result = await signCapabilityInvocation({
+          url: 'https://www.test.org/read/foo',
+          method: 'post',
+          headers: undefined,
+          json: {foo: true},
+          invocationSigner,
+          capabilityAction: 'read'
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.should.be.an.instanceOf(Error);
     });
+
     it.skip('a root zCap with out an invocationSigner', async function() {
 
     });
+
     it.skip('a root zCap with out a capabilityAction', async function() {
 
     });
+
     it.skip('a root zCap with out a url', async function() {
 
     });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -2,6 +2,11 @@ const {signCapabilityInvocation} = require('../index');
 const {Ed25519KeyPair} = require('crypto-ld');
 const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
 
+/**
+ * Reading
+ * @see https://w3c-ccg.github.io/zcap-ld/
+ */
+
 describe('signCapabilityInvocation', function() {
   let ed25519Key, keyId = null;
   before(async function() {
@@ -9,21 +14,84 @@ describe('signCapabilityInvocation', function() {
     keyId = 'did:key:foo';
     ed25519Key.id = keyId;
   });
-  it('should sign a root zCap', async function() {
-    const invocationSigner = ed25519Key.signer();
-    invocationSigner.id = keyId;
-    const signed = await signCapabilityInvocation({
-      url: 'https://www.test.org/read/foo',
-      method: 'GET',
-      headers: {
-        keyId,
-        date: new Date().toUTCString()
-      },
-      json: {foo: true},
-      invocationSigner,
-      capabilityAction: 'read'
+  describe('should sign', function() {
+    it('a valid root zCap', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
     });
-    console.log('signed', signed);
-    shouldBeAnAuthorizedRequest(signed);
+    it('a valid zCap with a capability string', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capability: 'test',
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+    });
+  });
+  describe('should NOT sign', function() {
+    it('a root zCap with out a method', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      let error, result = null;
+      try {
+        result = await signCapabilityInvocation({
+          url: 'https://www.test.org/read/foo',
+          method: undefined,
+          headers: {
+            keyId,
+            date: new Date().toUTCString()
+          },
+          json: {foo: true},
+          invocationSigner,
+          capabilityAction: 'read'
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.exist(error);
+      /**
+       * FIXME this causes mocha to fail the test
+       * with the error signCapabilityInvocation threw.
+      error.should.be.an('object');
+
+      */
+      should.not.exist(result);
+      error.code.should.exist;
+      error.code.should.be.a('string');
+    });
+    it.skip('a root zCap with out headers', async function() {
+
+    });
+    it.skip('a root zCap with out an invocationSigner', async function() {
+
+    });
+    it.skip('a root zCap with out a capabilityAction', async function() {
+
+    });
+    it.skip('a root zCap with out a url', async function() {
+
+    });
+
   });
 });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,6 +1,7 @@
 const {HttpSignatureError} = require('http-signature-header');
+const uuid = require('uuid-random');
 const {signCapabilityInvocation} = require('../index');
-const {Ed25519KeyPair} = require('crypto-ld');
+const {Ed25519KeyPair, RSAKeyPair} = require('crypto-ld');
 const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
 
 // TODO verify results using zvap-verify
@@ -17,366 +18,358 @@ const invocationSignError = new HttpSignatureError(
 const capabilityError = new HttpSignatureError(
   'capability is undefined', 'ConstraintError');
 
+// Future Tests can expand this array
+// to test additional LDKeyPairs
+const keyPairs = [
+  {name: 'Ed25519KeyPair', KeyPair: Ed25519KeyPair},
+  {name: 'RSAKeyPair', KeyPair: RSAKeyPair}
+];
+
 describe('signCapabilityInvocation', function() {
-  let ed25519Key, keyId = null;
-  before(async function() {
-    ed25519Key = await Ed25519KeyPair.generate();
-    keyId = 'did:key:foo';
-    ed25519Key.id = keyId;
-  });
-
-  describe('should sign', function() {
-
-    it('a valid root zCap', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid zCap with a capability string', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capability: 'test',
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid zCap with a capability object', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capability: {id: 'test'},
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid root zCap with host in the headers', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          host: 'www.test.org',
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid root zCap with a capabilityAction', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capabilityAction: 'action'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid root zCap with json', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-      should.exist(signed['content-type']);
-      signed['content-type'].should.be.a('string');
-      signed['content-type'].should.contain('application/json');
-    });
-
-    it('a valid root zCap with out json', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      should.not.exist(signed.digest);
-    });
-
-    it('a valid root zCap with digest', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          digest: 'f93a541ae8cd64d13d4054abacccb1cb',
-          keyId,
-          date: new Date().toUTCString()
-        },
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a root zCap with out a capabilityAction', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          keyId,
-          date: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capability: 'test'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-    it('a valid root zCap with UPPERCASE headers', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      const signed = await signCapabilityInvocation({
-        url: 'https://www.test.org/read/foo',
-        method: 'GET',
-        headers: {
-          KEYID: keyId,
-          DATE: new Date().toUTCString()
-        },
-        json: {foo: true},
-        invocationSigner,
-        capabilityAction: 'read'
-      });
-      shouldBeAnAuthorizedRequest(signed);
-      signed.digest.should.exist;
-      signed.digest.should.be.a('string');
-    });
-
-  });
-
-  describe('should NOT sign', function() {
-
-    it('a root zCap with out a method', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      let error, result = null;
-      try {
-        result = await signCapabilityInvocation({
-          url: 'https://www.test.org/read/foo',
-          method: undefined,
-          headers: {
-            keyId,
-            date: new Date().toUTCString()
-          },
-          json: {foo: true},
-          invocationSigner,
-          capabilityAction: 'read'
+  const keyId = 'did:key:foo';
+  describe('should sign with a(n)', function() {
+    keyPairs.forEach(function(keyType) {
+      describe(keyType.name, function() {
+        let invocationSigner = null;
+        const {KeyPair} = keyType;
+        beforeEach(async function() {
+          invocationSigner = (await KeyPair.generate()).signer();
+          invocationSigner.id = `${keyId}:${uuid()}`;
         });
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(result);
-      should.exist(error);
-      error.should.be.an.instanceOf(Error);
-      error.code.should.exist;
-      error.code.should.be.a('string');
-      error.code.should.contain('ERR_ASSERTION');
-    });
 
-    it('a root zCap with out headers', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      let error, result = null;
-      try {
-        result = await signCapabilityInvocation({
-          url: 'https://www.test.org/read/foo',
-          method: 'post',
-          headers: undefined,
-          json: {foo: true},
-          invocationSigner,
-          capabilityAction: 'read'
-        });
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(result);
-      should.exist(error);
-      error.should.be.an.instanceOf(Error);
-      error.name.should.contain('TypeError');
-      error.message.should.contain(
-        'Cannot convert undefined or null to object');
-    });
-
-    it('a root zCap with out an invocationSigner', async function() {
-      let error, result = null;
-      try {
-        result = await signCapabilityInvocation({
-          url: 'https://www.test.org/read/foo',
-          method: 'post',
-          headers: {
-            keyId,
-            date: new Date().toUTCString()
-          },
-          json: {foo: true},
-          capabilityAction: 'read'
-        });
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(result);
-      should.exist(error);
-      error.should.be.an.instanceOf(HttpSignatureError);
-      error.message.should.equal(invocationSignerError.message);
-      error.name.should.equal(invocationSignerError.name);
-    });
-
-    it('a root zCap with out an invocationSigner.sign method',
-      async function() {
-        const invocationSigner = ed25519Key.signer();
-        invocationSigner.id = keyId;
-        // remove the sign method
-        delete invocationSigner.sign;
-        let error, result = null;
-        try {
-          result = await signCapabilityInvocation({
+        it('a valid root zCap', async function() {
+          const signed = await signCapabilityInvocation({
             url: 'https://www.test.org/read/foo',
-            method: 'post',
+            method: 'GET',
             headers: {
               keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
-            capabilityAction: 'read',
-            invocationSigner
+            invocationSigner,
+            capabilityAction: 'read'
           });
-        } catch(e) {
-          error = e;
-        }
-        should.not.exist(result);
-        should.exist(error);
-        error.should.be.an.instanceOf(HttpSignatureError);
-        error.message.should.equal(invocationSignError.message);
-        error.name.should.equal(invocationSignError.name);
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid zCap with a capability string', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capability: 'test',
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid zCap with a capability object', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capability: {id: 'test'},
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid root zCap with host in the headers', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              host: 'www.test.org',
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid root zCap with a capabilityAction', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capabilityAction: 'action'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid root zCap with json', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+          should.exist(signed['content-type']);
+          signed['content-type'].should.be.a('string');
+          signed['content-type'].should.contain('application/json');
+        });
+
+        it('a valid root zCap with out json', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            invocationSigner,
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          should.not.exist(signed.digest);
+        });
+
+        it('a valid root zCap with digest', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              digest: 'f93a541ae8cd64d13d4054abacccb1cb',
+              keyId,
+              date: new Date().toUTCString()
+            },
+            invocationSigner,
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a root zCap with out a capabilityAction', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              keyId,
+              date: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capability: 'test'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
+
+        it('a valid root zCap with UPPERCASE headers', async function() {
+          const signed = await signCapabilityInvocation({
+            url: 'https://www.test.org/read/foo',
+            method: 'GET',
+            headers: {
+              KEYID: keyId,
+              DATE: new Date().toUTCString()
+            },
+            json: {foo: true},
+            invocationSigner,
+            capabilityAction: 'read'
+          });
+          shouldBeAnAuthorizedRequest(signed);
+          signed.digest.should.exist;
+          signed.digest.should.be.a('string');
+        });
       });
 
-    it('a root zCap with out a url and host', async function() {
-      const invocationSigner = ed25519Key.signer();
-      invocationSigner.id = keyId;
-      let error, result = null;
-      try {
-        result = await signCapabilityInvocation({
-          method: 'post',
-          headers: {
-            keyId,
-            date: new Date().toUTCString()
-          },
-          json: {foo: true},
-          invocationSigner,
-          capabilityAction: 'read'
-        });
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(result);
-      should.exist(error);
-      error.should.be.an.instanceOf(Error);
-      error.name.should.contain('TypeError');
-      error.message.should.contain('Invalid URL');
     });
 
-    it('a zCap if the capability object has no id', async function() {
-      let result, error = null;
-      try {
-        const invocationSigner = ed25519Key.signer();
-        invocationSigner.id = keyId;
-        result = await signCapabilityInvocation({
-          url: 'https://www.test.org/read/foo',
-          method: 'GET',
-          headers: {
-            keyId,
-            date: new Date().toUTCString()
-          },
-          json: {foo: true},
-          invocationSigner,
-          capability: {}
+  });
+
+  describe('should NOT sign with a(n) ', function() {
+    keyPairs.forEach(function(keyType) {
+      describe(keyType.name, function() {
+        let invocationSigner = null;
+        const {KeyPair} = keyType;
+        beforeEach(async function() {
+          invocationSigner = (await KeyPair.generate()).signer();
+          invocationSigner.id = `${keyId}:${uuid()}`;
         });
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(result);
-      should.exist(error);
-      error.should.be.an.instanceOf(HttpSignatureError);
-      error.message.should.equal(capabilityError.message);
-      error.name.should.equal(capabilityError.name);
+
+        it('a root zCap with out a method', async function() {
+          let error, result = null;
+          try {
+            result = await signCapabilityInvocation({
+              url: 'https://www.test.org/read/foo',
+              method: undefined,
+              headers: {
+                keyId,
+                date: new Date().toUTCString()
+              },
+              json: {foo: true},
+              invocationSigner,
+              capabilityAction: 'read'
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(Error);
+          error.code.should.exist;
+          error.code.should.be.a('string');
+          error.code.should.contain('ERR_ASSERTION');
+        });
+
+        it('a root zCap with out headers', async function() {
+          let error, result = null;
+          try {
+            result = await signCapabilityInvocation({
+              url: 'https://www.test.org/read/foo',
+              method: 'post',
+              headers: undefined,
+              json: {foo: true},
+              invocationSigner,
+              capabilityAction: 'read'
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(Error);
+          error.name.should.contain('TypeError');
+          error.message.should.contain(
+            'Cannot convert undefined or null to object');
+        });
+
+        it('a root zCap with out an invocationSigner', async function() {
+          let error, result = null;
+          try {
+            result = await signCapabilityInvocation({
+              url: 'https://www.test.org/read/foo',
+              method: 'post',
+              headers: {
+                keyId,
+                date: new Date().toUTCString()
+              },
+              json: {foo: true},
+              capabilityAction: 'read'
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(HttpSignatureError);
+          error.message.should.equal(invocationSignerError.message);
+          error.name.should.equal(invocationSignerError.name);
+        });
+
+        it('a root zCap with out an invocationSigner.sign method',
+          async function() {
+            // remove the sign method
+            delete invocationSigner.sign;
+            let error, result = null;
+            try {
+              result = await signCapabilityInvocation({
+                url: 'https://www.test.org/read/foo',
+                method: 'post',
+                headers: {
+                  keyId,
+                  date: new Date().toUTCString()
+                },
+                json: {foo: true},
+                capabilityAction: 'read',
+                invocationSigner
+              });
+            } catch(e) {
+              error = e;
+            }
+            should.not.exist(result);
+            should.exist(error);
+            error.should.be.an.instanceOf(HttpSignatureError);
+            error.message.should.equal(invocationSignError.message);
+            error.name.should.equal(invocationSignError.name);
+          });
+
+        it('a root zCap with out a url and host', async function() {
+          let error, result = null;
+          try {
+            result = await signCapabilityInvocation({
+              method: 'post',
+              headers: {
+                keyId,
+                date: new Date().toUTCString()
+              },
+              json: {foo: true},
+              invocationSigner,
+              capabilityAction: 'read'
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(Error);
+          error.name.should.contain('TypeError');
+          error.message.should.contain('Invalid URL');
+        });
+
+        it('a zCap if the capability object has no id', async function() {
+          let result, error = null;
+          try {
+            result = await signCapabilityInvocation({
+              url: 'https://www.test.org/read/foo',
+              method: 'GET',
+              headers: {
+                keyId,
+                date: new Date().toUTCString()
+              },
+              json: {foo: true},
+              invocationSigner,
+              capability: {}
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(HttpSignatureError);
+          error.message.should.equal(capabilityError.message);
+          error.name.should.equal(capabilityError.name);
+        });
+      });
     });
   });
 });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -2,6 +2,8 @@ const {signCapabilityInvocation} = require('../index');
 const {Ed25519KeyPair} = require('crypto-ld');
 const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
 
+// TODO verify results using zvap-verify
+
 /**
  * Reading
  * @see https://w3c-ccg.github.io/zcap-ld/

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -1,15 +1,15 @@
 const {signCapabilityInvocation} = require('../index');
 const {Ed25519KeyPair} = require('crypto-ld');
-const {authorizedRequest} = require('./test-assertions');
+const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
 
 describe('signCapabilityInvocation', function() {
   let ed25519Key, keyId = null;
   before(async function() {
     ed25519Key = await Ed25519KeyPair.generate();
-    keyId = 'did:test:foo';
+    keyId = 'did:key:foo';
     ed25519Key.id = keyId;
   });
-  it('should sign basic request', async function() {
+  it('should sign a root zCap', async function() {
     const invocationSigner = ed25519Key.signer();
     invocationSigner.id = keyId;
     const signed = await signCapabilityInvocation({
@@ -24,6 +24,6 @@ describe('signCapabilityInvocation', function() {
       capabilityAction: 'read'
     });
     console.log('signed', signed);
-    authorizedRequest(signed);
+    shouldBeAnAuthorizedRequest(signed);
   });
 });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -34,6 +34,8 @@ describe('signCapabilityInvocation', function() {
         capabilityAction: 'read'
       });
       shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
     });
 
     it('a valid zCap with a capability string', async function() {
@@ -52,6 +54,8 @@ describe('signCapabilityInvocation', function() {
         capabilityAction: 'read'
       });
       shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
     });
 
     it('a valid zCap with a capability object', async function() {
@@ -70,6 +74,83 @@ describe('signCapabilityInvocation', function() {
         capabilityAction: 'read'
       });
       shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
+    });
+
+    it('a valid root zCap with host in the headers', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          host: 'www.test.org',
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
+    });
+
+    it('a valid root zCap with a capabilityAction', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capabilityAction: 'action'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
+    });
+
+    it('a valid root zCap with out json', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          keyId,
+          date: new Date().toUTCString()
+        },
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      should.not.exist(signed.digest);
+    });
+
+    it('a valid root zCap with digest', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          digest: 'f93a541ae8cd64d13d4054abacccb1cb',
+          keyId,
+          date: new Date().toUTCString()
+        },
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
     });
 
     it('a root zCap with out a capabilityAction', async function() {
@@ -87,6 +168,27 @@ describe('signCapabilityInvocation', function() {
         capability: 'test'
       });
       shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
+    });
+
+    it('a valid root zCap with UPPERCASE headers', async function() {
+      const invocationSigner = ed25519Key.signer();
+      invocationSigner.id = keyId;
+      const signed = await signCapabilityInvocation({
+        url: 'https://www.test.org/read/foo',
+        method: 'GET',
+        headers: {
+          KEYID: keyId,
+          DATE: new Date().toUTCString()
+        },
+        json: {foo: true},
+        invocationSigner,
+        capabilityAction: 'read'
+      });
+      shouldBeAnAuthorizedRequest(signed);
+      signed.digest.should.exist;
+      signed.digest.should.be.a('string');
     });
 
   });

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -122,10 +122,30 @@ describe('signCapabilityInvocation', function() {
       should.not.exist(result);
       should.exist(error);
       error.should.be.an.instanceOf(Error);
+      error.name.should.contain('TypeError');
+      error.message.should.contain(
+        'Cannot convert undefined or null to object');
     });
 
-    it.skip('a root zCap with out an invocationSigner', async function() {
-
+    it('a root zCap with out an invocationSigner', async function() {
+      let error, result = null;
+      try {
+        result = await signCapabilityInvocation({
+          url: 'https://www.test.org/read/foo',
+          method: 'post',
+          headers: {
+            keyId,
+            date: new Date().toUTCString()
+          },
+          json: {foo: true},
+          capabilityAction: 'read'
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.should.be.an.instanceOf(Error);
     });
 
     it.skip('a root zCap with out a capabilityAction', async function() {

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -146,6 +146,7 @@ describe('signCapabilityInvocation', function() {
       should.not.exist(result);
       should.exist(error);
       error.should.be.an.instanceOf(Error);
+      error.message.should.contain('invocationSigner');
     });
 
     it.skip('a root zCap with out a capabilityAction', async function() {

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -1,4 +1,4 @@
-const authorizedRequest = actualResult => {
+const shouldBeAnAuthorizedRequest = actualResult => {
   should.exist(actualResult);
   actualResult.should.be.an('object');
   actualResult.keyid.should.exist;
@@ -16,4 +16,4 @@ const authorizedRequest = actualResult => {
   actualResult.authorization.should.contain('signature');
 };
 
-exports.authorizedRequest = authorizedRequest;
+exports.shouldBeAnAuthorizedRequest = shouldBeAnAuthorizedRequest;

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -1,0 +1,19 @@
+const authorizedRequest = actualResult => {
+  should.exist(actualResult);
+  actualResult.should.be.an('object');
+  actualResult.keyid.should.exist;
+  actualResult.keyid.should.be.a('string');
+  actualResult.date.should.exist;
+  actualResult.date.should.be.a('string');
+  actualResult.host.should.exist;
+  actualResult.host.should.be.a('string');
+  actualResult.digest.should.exist;
+  actualResult.digest.should.be.a('string');
+  actualResult.authorization.should.exist;
+  actualResult.authorization.should.be.a('string');
+  actualResult.authorization.should.contain('keyId');
+  actualResult.authorization.should.contain('headers');
+  actualResult.authorization.should.contain('signature');
+};
+
+exports.authorizedRequest = authorizedRequest;

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -7,8 +7,6 @@ const shouldBeAnAuthorizedRequest = actualResult => {
   actualResult.date.should.be.a('string');
   actualResult.host.should.exist;
   actualResult.host.should.be.a('string');
-  actualResult.digest.should.exist;
-  actualResult.digest.should.be.a('string');
   actualResult.authorization.should.exist;
   actualResult.authorization.should.be.a('string');
   actualResult.authorization.should.contain('keyId');

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -14,6 +14,8 @@ const shouldBeAnAuthorizedRequest = actualResult => {
   actualResult.authorization.should.contain('keyId');
   actualResult.authorization.should.contain('headers');
   actualResult.authorization.should.contain('signature');
+  actualResult['capability-invocation'].should.exist;
+  actualResult['capability-invocation'].should.contain('zcap');
 };
 
 exports.shouldBeAnAuthorizedRequest = shouldBeAnAuthorizedRequest;

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -5,8 +5,6 @@ const shouldBeAnAuthorizedRequest = actualResult => {
   actualResult.keyid.should.be.a('string');
   actualResult.date.should.exist;
   actualResult.date.should.be.a('string');
-  actualResult.host.should.exist;
-  actualResult.host.should.be.a('string');
   actualResult.authorization.should.exist;
   actualResult.authorization.should.be.a('string');
   actualResult.authorization.should.contain('keyId');

--- a/tests/test-karma.js
+++ b/tests/test-karma.js
@@ -1,0 +1,8 @@
+/**
+ * Karma test support.
+ *
+ * Copyright (c) 2011-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+// load polyfills
+// no polyfills are currently required.
+

--- a/tests/test-mocha.js
+++ b/tests/test-mocha.js
@@ -1,0 +1,2 @@
+const chai = require('chai');
+global.should = chai.should();


### PR DESCRIPTION
```
  signCapabilityInvocation
    should sign with a(n)
      Ed25519KeyPair
        ✓ a valid root zCap
        ✓ a valid zCap with a capability string
        ✓ a valid zCap with a capability object
        ✓ a valid root zCap with host in the headers
        ✓ a valid root zCap with a capabilityAction
        ✓ a valid root zCap with json
        ✓ a valid root zCap with out json
        ✓ a valid root zCap with digest
        ✓ a root zCap with out a capabilityAction
        ✓ a valid root zCap with UPPERCASE headers
      RSAKeyPair
        ✓ a valid root zCap
        ✓ a valid zCap with a capability string
        ✓ a valid zCap with a capability object
        ✓ a valid root zCap with host in the headers
        ✓ a valid root zCap with a capabilityAction
        ✓ a valid root zCap with json
        ✓ a valid root zCap with out json
        ✓ a valid root zCap with digest
        ✓ a root zCap with out a capabilityAction
        ✓ a valid root zCap with UPPERCASE headers
    should NOT sign with a(n) 
      Ed25519KeyPair
        ✓ a root zCap with out a HTTP method
        ✓ a root zCap with out headers
        ✓ a root zCap with out an invocationSigner
        ✓ a root zCap with out an invocationSigner.sign method
        ✓ a root zCap with out a url and host
        ✓ a zCap if the capability object has no id
      RSAKeyPair
        ✓ a root zCap with out a HTTP method
        ✓ a root zCap with out headers
        ✓ a root zCap with out an invocationSigner
        ✓ a root zCap with out an invocationSigner.sign method
        ✓ a root zCap with out a url and host
        ✓ a zCap if the capability object has no id


  32 passing (2s)


=============================== Coverage summary ===============================
Statements   : 97.73% ( 43/44 )
Branches     : 91.3% ( 21/23 )
Functions    : 100% ( 2/2 )
Lines        : 97.73% ( 43/44 )
================================================================================
```

Karma tests have 2 failing tests I have to skip due to assert-plus being disabled in browsers:

```
04 02 2020 12:52:26.636:INFO [launcher]: Starting browser ChromeHeadless
04 02 2020 12:52:27.028:INFO [HeadlessChrome 79.0.3945 (Linux 0.0.0)]: Connected on socket -R1ka8ZS38KxVYfYAAAA with id 18872705
  signCapabilityInvocation
    should sign with a(n)
      Ed25519KeyPair
        ✔ a valid root zCap
        ✔ a valid zCap with a capability string
        ✔ a valid zCap with a capability object
        ✔ a valid root zCap with host in the headers
        ✔ a valid root zCap with a capabilityAction
        ✔ a valid root zCap with json
        ✔ a valid root zCap with out json
        ✔ a valid root zCap with digest
        ✔ a root zCap with out a capabilityAction
        ✔ a valid root zCap with UPPERCASE headers
      RSAKeyPair
        ✔ a valid root zCap
        ✔ a valid zCap with a capability string
        ✔ a valid zCap with a capability object
        ✔ a valid root zCap with host in the headers
        ✔ a valid root zCap with a capabilityAction
        ✔ a valid root zCap with json
        ✔ a valid root zCap with out json
        ✔ a valid root zCap with digest
        ✔ a root zCap with out a capabilityAction
        ✔ a valid root zCap with UPPERCASE headers
    should NOT sign with a(n) 
      Ed25519KeyPair
        ✖ a root zCap with out a HTTP method (skipped)
        ✔ a root zCap with out headers
        ✔ a root zCap with out an invocationSigner
        ✔ a root zCap with out an invocationSigner.sign method
        ✔ a root zCap with out a url and host
        ✔ a zCap if the capability object has no id
      RSAKeyPair
        ✖ a root zCap with out a HTTP method (skipped)
        ✔ a root zCap with out headers
        ✔ a root zCap with out an invocationSigner
        ✔ a root zCap with out an invocationSigner.sign method
        ✔ a root zCap with out a url and host
        ✔ a zCap if the capability object has no id

Finished in 4.054 secs / 0.736 secs @ 12:52:31 GMT-0500 (Eastern Standard Time)

SUMMARY:
✔ 30 tests completed
ℹ 2 tests skipped
```

NOTE: the with out a HTTP method test is disabled because http-signature-header will sign with out a method in browsers because assert-plus is disabled:

https://github.com/digitalbazaar/http-signature-header/blob/0356d7fcde9fd3e42eb3847d3f5bf31a3cfad866/lib/index.js#L18-L23


This test project will be continued in this issue: https://github.com/digitalbazaar/http-signature-zcap-invoke/issues/4  when time allows.

This should satisfy most of this issue:
https://github.com/digitalbazaar/http-signature-zcap-invoke/issues/2
