### PR TITLE
Use isomorphic-webcrypto@2.3.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "base64url-universal": "^1.0.0",
     "esm": "^3.2.22",
-    "isomorphic-webcrypto": "^1.6.1",
+    "isomorphic-webcrypto": "^2.3.4",
     "http-signature-header": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is same version webkms-client is using.  There does not seem to be a changelog in the webcrypto module so I have no idea what may be going on or even if they are using semver.