### PR TITLE
Verify tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: node_js
+node_js:
+  - "8"
+  - "10"
+  - "12"
+  - "node"
+sudo: false
+install:
+  - npm install
+script:
+  - if [ "x$BUNDLER" = "x" ]; then npm run test; fi
+  - if [ "x$BUNDLER" != "x" ]; then npm run test-karma; fi
+# only run karma tests for one node version
+matrix:
+  include:
+  - name: "Browser Unit Tests (webpack)"
+    node_js: "12"
+    env: BUNDLER=webpack
+  - name: "Browser Unit Tests (browserify)"
+    node_js: "12"
+    env: BUNDLER=browserify
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "crypto-ld": "^3.7.0",
     "eslint": "^6.8.0",
     "eslint-config-digitalbazaar": "^2.0.0",
+    "http-signature-zcap-verify": "^1.2.1",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -87,7 +87,7 @@ const verify = async ({signed, Suite, keyPair}) => {
         document: rootCapability
       };
     }
-    throw new Error(`documentLoader unable to resolve ${uri}`);
+    throw new Error(`documentLoader unable to resolve "${uri}"`);
   };
   const getInvokedCapability = () => rootCapability;
   const {verified, error} = await verifyCapabilityInvocation({

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -2,6 +2,7 @@ const uuid = require('uuid-random');
 const {signCapabilityInvocation} = require('../main');
 const {Ed25519KeyPair, RSAKeyPair} = require('crypto-ld');
 const {shouldBeAnAuthorizedRequest} = require('./test-assertions');
+const {verifyCapabilityInvocation} = require('http-signature-zcap-verify');
 
 // TODO verify results using zvap-verify
 
@@ -24,6 +25,15 @@ const keyPairs = [
   {name: 'RSAKeyPair', KeyPair: RSAKeyPair}
 ];
 
+const url = 'https://www.test.org/read/foo';
+const method = 'GET';
+
+const verify = async ({signed, invocationSigner}) => {
+  const {verified} = await verifyCapabilityInvocation({
+
+  });
+};
+
 describe('signCapabilityInvocation', function() {
   const keyId = 'did:key:foo';
   describe('should sign with a(n)', function() {
@@ -38,8 +48,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -55,8 +65,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid zCap with a capability string', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -73,8 +83,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid zCap with a capability object', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -91,8 +101,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap with host in the headers', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               host: 'www.test.org',
               keyId,
@@ -109,8 +119,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap with a capabilityAction', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -126,8 +136,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap with json', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -146,8 +156,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap with out json', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -162,8 +172,8 @@ describe('signCapabilityInvocation', function() {
         it('a valid root zCap with digest', async function() {
           const digest = 'f93a541ae8cd64d13d4054abacccb1cb';
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               digest,
               keyId,
@@ -180,8 +190,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a root zCap with out a capabilityAction', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               keyId,
               date: new Date().toUTCString()
@@ -197,8 +207,8 @@ describe('signCapabilityInvocation', function() {
 
         it('a valid root zCap with UPPERCASE headers', async function() {
           const signed = await signCapabilityInvocation({
-            url: 'https://www.test.org/read/foo',
-            method: 'GET',
+            url,
+            method,
             headers: {
               KEYID: keyId,
               DATE: new Date().toUTCString()
@@ -212,9 +222,7 @@ describe('signCapabilityInvocation', function() {
           signed.digest.should.be.a('string');
         });
       });
-
     });
-
   });
 
   describe('should NOT sign with a(n) ', function() {
@@ -239,7 +247,7 @@ describe('signCapabilityInvocation', function() {
           let error, result = null;
           try {
             result = await signCapabilityInvocation({
-              url: 'https://www.test.org/read/foo',
+              url,
               headers: {
                 keyId,
                 date: new Date().toUTCString()
@@ -263,7 +271,7 @@ describe('signCapabilityInvocation', function() {
           let error, result = null;
           try {
             result = await signCapabilityInvocation({
-              url: 'https://www.test.org/read/foo',
+              url,
               method: 'post',
               headers: undefined,
               json: {foo: true},
@@ -285,7 +293,7 @@ describe('signCapabilityInvocation', function() {
           let error, result = null;
           try {
             result = await signCapabilityInvocation({
-              url: 'https://www.test.org/read/foo',
+              url,
               method: 'post',
               headers: {
                 keyId,
@@ -311,7 +319,7 @@ describe('signCapabilityInvocation', function() {
             let error, result = null;
             try {
               result = await signCapabilityInvocation({
-                url: 'https://www.test.org/read/foo',
+                url,
                 method: 'post',
                 headers: {
                   keyId,
@@ -358,7 +366,7 @@ describe('signCapabilityInvocation', function() {
           let result, error = null;
           try {
             result = await signCapabilityInvocation({
-              url: 'https://www.test.org/read/foo',
+              url,
               method: 'GET',
               headers: {
                 keyId,

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -342,6 +342,8 @@ describe('signCapabilityInvocation', function() {
           should.not.exist(result);
           should.exist(error);
           error.should.be.an.instanceOf(Error);
+          error.message.should.contain(
+            '"capability" must be a string or an object.');
         });
 
         it('a root zCap with out a HTTP method', async function() {

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -321,6 +321,29 @@ describe('signCapabilityInvocation', function() {
           invocationSigner.id = `${keyId}:${uuid()}`;
         });
 
+        it('a zCap without a capability', async function() {
+          let error, result = null;
+          try {
+            result = await signCapabilityInvocation({
+              url,
+              method,
+              headers: {
+                keyId,
+                date: new Date().toUTCString()
+              },
+              json: {foo: true},
+              invocationSigner,
+              capability: null,
+              capabilityAction: 'read'
+            });
+          } catch(e) {
+            error = e;
+          }
+          should.not.exist(result);
+          should.exist(error);
+          error.should.be.an.instanceOf(Error);
+        });
+
         it('a root zCap with out a HTTP method', async function() {
 
           // detect browser environment
@@ -422,6 +445,34 @@ describe('signCapabilityInvocation', function() {
             should.exist(error);
             error.should.be.an.instanceOf(TypeError);
             error.message.should.equal(invocationSignError.message);
+            error.name.should.equal(invocationSignError.name);
+          });
+
+        it('a root zCap with an invocationSigner.sign that is not a function',
+          async function() {
+            // remove the sign method
+            invocationSigner.sign = 'foo';
+            let error, result = null;
+            try {
+              result = await signCapabilityInvocation({
+                url,
+                method: 'post',
+                headers: {
+                  keyId,
+                  date: new Date().toUTCString()
+                },
+                json: {foo: true},
+                capabilityAction: 'read',
+                invocationSigner
+              });
+            } catch(e) {
+              error = e;
+            }
+            should.not.exist(result);
+            should.exist(error);
+            error.should.be.an.instanceOf(TypeError);
+            error.message.should.equal(
+              'invocationSigner must have a sign method');
             error.name.should.equal(invocationSignError.name);
           });
 

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -27,11 +27,25 @@ const keyPairs = [
 
 const url = 'https://www.test.org/read/foo';
 const method = 'GET';
+const controller = 'did:test:controller';
 
 const verify = async ({signed, invocationSigner}) => {
-  const {verified} = await verifyCapabilityInvocation({
+  const {host} = new URL(url);
+  signed.host = signed.host || host;
+  const documentLoader = async uri => {
 
+  };
+  const {verified} = await verifyCapabilityInvocation({
+    url,
+    method,
+    expectedHost: host,
+    headers: signed,
+    expectedTarget: url,
+    keyId: invocationSigner.id
   });
+  should.exist(verified);
+  verified.should.be.a('boolean');
+  verified.should.equal(true);
 };
 
 describe('signCapabilityInvocation', function() {
@@ -39,11 +53,13 @@ describe('signCapabilityInvocation', function() {
   describe('should sign with a(n)', function() {
     keyPairs.forEach(function(keyType) {
       describe(keyType.name, function() {
-        let invocationSigner = null;
+        let invocationSigner, keyPair = null;
         const {KeyPair} = keyType;
         beforeEach(async function() {
-          invocationSigner = (await KeyPair.generate()).signer();
-          invocationSigner.id = `${keyId}:${uuid()}`;
+          const _id = `${keyId}:${uuid()}`;
+          keyPair = await KeyPair.generate({controller, id: _id});
+          invocationSigner = keyPair.signer();
+          invocationSigner.id = _id;
         });
 
         it('a valid root zCap', async function() {


### PR DESCRIPTION
This PR ensures all positive tests produce signatures that can be verified by `http-signature-zcap-verify`. It address this issue: https://github.com/digitalbazaar/http-signature-zcap-invoke/issues/4
```
  signCapabilityInvocation
    should sign with a(n)
      Ed25519KeyPair
        ✓ a valid root zCap (42ms)
        ✓ a valid zCap with a capability string
        ✓ a valid zCap with a capability object
        ✓ a valid root zCap with host in the headers
        ✓ a valid root zCap with a capabilityAction
        ✓ a valid root zCap with json
        ✓ a valid root zCap with out json
        ✓ a valid root zCap with digest
        ✓ a root zCap with out a capabilityAction
        ✓ a valid root zCap with UPPERCASE headers
      RSAKeyPair
        ✓ a valid root zCap
        ✓ a valid zCap with a capability string
        ✓ a valid zCap with a capability object
        ✓ a valid root zCap with host in the headers
        ✓ a valid root zCap with a capabilityAction
        ✓ a valid root zCap with json
        ✓ a valid root zCap with out json
        ✓ a valid root zCap with digest
        ✓ a root zCap with out a capabilityAction
        ✓ a valid root zCap with UPPERCASE headers
    should NOT sign with a(n) 
      Ed25519KeyPair
        ✓ a zCap without a capability
        ✓ a root zCap with out a HTTP method
        ✓ a root zCap with out headers
        ✓ a root zCap with out an invocationSigner
        ✓ a root zCap with out an invocationSigner.sign method
        ✓ a root zCap with an invocationSigner.sign that is not a function
        ✓ a root zCap with out a url and host
        ✓ a zCap if the capability object has no id
      RSAKeyPair
        ✓ a zCap without a capability
        ✓ a root zCap with out a HTTP method
        ✓ a root zCap with out headers
        ✓ a root zCap with out an invocationSigner
        ✓ a root zCap with out an invocationSigner.sign method
        ✓ a root zCap with an invocationSigner.sign that is not a function
        ✓ a root zCap with out a url and host
        ✓ a zCap if the capability object has no id


  36 passing (2s)

-----------|----------|----------|----------|----------|-------------------|
File       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------|----------|----------|----------|----------|-------------------|
All files  |    97.96 |     93.1 |      100 |    97.96 |                   |
 crypto.js |        0 |        0 |        0 |        0 |                   |
 main.js   |    97.92 |     93.1 |      100 |    97.92 |               125 |
 util.js   |      100 |      100 |      100 |      100 |                   |
-----------|----------|----------|----------|----------|-------------------|
```

```
=============================== Coverage summary ===============================
Statements   : 97.96% ( 48/49 )
Branches     : 93.1% ( 27/29 )
Functions    : 100% ( 3/3 )
Lines        : 97.96% ( 48/49 )
================================================================================
```

The only statement not being covered occurs when `isBrowser` is true which is tested when the karma tests run.
This also adds 2 new tests that cover one new statement and one previously uncovered state.