### PR TITLE
Remove keyId from tests (not required for invocation).

### DIFF
--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -126,7 +126,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -144,7 +143,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -164,7 +162,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -184,7 +181,6 @@ describe('signCapabilityInvocation', function() {
             method,
             headers: {
               host: 'www.test.org',
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -202,7 +198,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -220,7 +215,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -241,7 +235,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             invocationSigner,
@@ -259,7 +252,6 @@ describe('signCapabilityInvocation', function() {
             method,
             headers: {
               digest,
-              keyId,
               date: new Date().toUTCString()
             },
             invocationSigner,
@@ -277,7 +269,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              keyId,
               date: new Date().toUTCString()
             },
             json: {foo: true},
@@ -295,7 +286,6 @@ describe('signCapabilityInvocation', function() {
             url,
             method,
             headers: {
-              KEYID: keyId,
               DATE: new Date().toUTCString()
             },
             json: {foo: true},
@@ -328,7 +318,6 @@ describe('signCapabilityInvocation', function() {
               url,
               method,
               headers: {
-                keyId,
                 date: new Date().toUTCString()
               },
               json: {foo: true},
@@ -360,7 +349,6 @@ describe('signCapabilityInvocation', function() {
             result = await signCapabilityInvocation({
               url,
               headers: {
-                keyId,
                 date: new Date().toUTCString()
               },
               json: {foo: true},
@@ -407,7 +395,6 @@ describe('signCapabilityInvocation', function() {
               url,
               method: 'post',
               headers: {
-                keyId,
                 date: new Date().toUTCString()
               },
               json: {foo: true},
@@ -433,7 +420,6 @@ describe('signCapabilityInvocation', function() {
                 url,
                 method: 'post',
                 headers: {
-                  keyId,
                   date: new Date().toUTCString()
                 },
                 json: {foo: true},
@@ -460,7 +446,6 @@ describe('signCapabilityInvocation', function() {
                 url,
                 method: 'post',
                 headers: {
-                  keyId,
                   date: new Date().toUTCString()
                 },
                 json: {foo: true},
@@ -484,7 +469,6 @@ describe('signCapabilityInvocation', function() {
             result = await signCapabilityInvocation({
               method: 'post',
               headers: {
-                keyId,
                 date: new Date().toUTCString()
               },
               json: {foo: true},
@@ -508,7 +492,6 @@ describe('signCapabilityInvocation', function() {
               url,
               method: 'GET',
               headers: {
-                keyId,
                 date: new Date().toUTCString()
               },
               json: {foo: true},

--- a/tests/test-assertions.js
+++ b/tests/test-assertions.js
@@ -1,8 +1,6 @@
 const shouldBeAnAuthorizedRequest = actualResult => {
   should.exist(actualResult);
   actualResult.should.be.an('object');
-  actualResult.keyid.should.exist;
-  actualResult.keyid.should.be.a('string');
   actualResult.date.should.exist;
   actualResult.date.should.be.a('string');
   actualResult.authorization.should.exist;


### PR DESCRIPTION
Remove superfluous keyId from tests as the value isn't required as a header parameter for invocation. The code was generating zcap headers that looked like the following (note duplication between keyid as header and as authorization parameter):

```
{
  keyid: 'did:key:z6MkvEdjELJc6R5bXX1UKuxd1FsBidyHkYXdqhjbyArnFidw#z6MkvEdjELJc6R5bXX1UKuxd1FsBidyHkYXdqhjbyArnFidw',
  date: 'Thu, 07 Jan 2021 19:10:09 GMT',
  host: 'localhost:11443',
  'capability-invocation': 'zcap id="https://localhost:11443/foo",action="write"',
  digest: 'mh=uEiA7moBk3umnvoNRRZ4fpsdWDtoslp3SC2I8C7TFbIRjOA',
  'content-type': 'application/json',
  authorization: 'Signature keyId="did:key:z6MkvEdjELJc6R5bXX1UKuxd1FsBidyHkYXdqhjbyArnFidw#z6MkvEdjELJc6R5bXX1UKuxd1FsBidyHkYXdqhjbyArnFidw",headers="(key-id) (created) (expires)
 (request-target) host capability-invocation content-type digest",signature="saypxrjTsdxPPvrLlr2NDzvP2TWrY5qqTzHeGbdogMcDPGP+ipWw/pjVK0hrE9PfxgRs4n/PHDUbRtHTMX0BBg==",created="161
0046609112",expires="1610047209112"'
}
```