### PR TITLE
`signCapabilityInvocation` accepts options.body Blob

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,8 +136,11 @@ export async function signCapabilityInvocation({
     const includeHeaders = [
       '(key-id)', '(created)', '(expires)', '(request-target)',
       'host', 'capability-invocation'];
-    if(body) {
+    // if has a type, sign over content-type, otherwise don't.
+    if (body?.type) {
       includeHeaders.push('content-type');
+    }
+    if(body) {
       includeHeaders.push('digest');
     }
     const plaintext = createSignatureString({

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,8 +22,9 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @param {string} options.url - The invocation target.
  * @param {string} options.method - An HTTP method.
  * @param {object} options.headers - The headers in the HTTP message.
+ * @param {Blob}   [options.body]   - request body, if any. Not allowed when options.json is provided.
  * @param {object} [options.json] - An optional json object representing an
- *   HTTP JSON body, if any.
+ *   HTTP JSON body, if any. Do not provide with options.body, which takes precedence.
  * @param {string|object} options.capability - Either a string to invoke a root
  *   zcap or a capability object to invoke a delegated zcap; this defaults to
  *   the root zcap expected to be associated with the url.
@@ -44,6 +45,7 @@ export async function signCapabilityInvocation({
   url,
   method,
   headers,
+  body,
   json,
   capability = `${ZCAP_ROOT_PREFIX}${encodeURIComponent(url)}`,
   capabilityAction,
@@ -104,12 +106,22 @@ export async function signCapabilityInvocation({
     }
     signed['capability-invocation'] = invocationHeader;
 
-    if(json && signed.digest === undefined) {
-      // compute digest for json
-      signed.digest = await createHeaderValue({data: json, useMultihash: true});
+    // options.body and options.json are not allowed at the same time.
+    // options.body was added after options.json, and may replace options.json in a future release.
+    if (body && json) throw new Error(`options.body and options.json MUST NOT be provided together`)
 
-      if(signed['content-type'] === undefined) {
-        signed['content-type'] = 'application/json';
+    // set body from options.json if options.body was not provided
+    if ( (!body) && json) {
+      // assign body from json
+      body = new Blob([typeof json === 'string' ? json : JSON.stringify(json)],{type:'application/json'})
+    }
+
+    if(body && signed.digest === undefined) {
+      // compute digest for body
+      signed.digest = await createHeaderValue({data: body, useMultihash: true});
+
+      if(signed['content-type'] === undefined && body.type) {
+        signed['content-type'] = body.type
       }
     }
     // convert dates to unix time stamp
@@ -124,7 +136,7 @@ export async function signCapabilityInvocation({
     const includeHeaders = [
       '(key-id)', '(created)', '(expires)', '(request-target)',
       'host', 'capability-invocation'];
-    if(json) {
+    if(body) {
       includeHeaders.push('content-type');
       includeHeaders.push('digest');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,11 @@ const ZCAP_ROOT_PREFIX = 'urn:zcap:root:';
  * @param {string} options.url - The invocation target.
  * @param {string} options.method - An HTTP method.
  * @param {object} options.headers - The headers in the HTTP message.
- * @param {Blob}   [options.body]   - request body, if any. Not allowed when options.json is provided.
+ * @param {Blob} [options.body] - Request body.
+ *  Not allowed when options.json is provided.
  * @param {object} [options.json] - An optional json object representing an
- *   HTTP JSON body, if any. Do not provide with options.body, which takes precedence.
+ *   HTTP JSON body, if any. Do not provide with options.body,
+ *   which takes precedence.
  * @param {string|object} options.capability - Either a string to invoke a root
  *   zcap or a capability object to invoke a delegated zcap; this defaults to
  *   the root zcap expected to be associated with the url.
@@ -107,13 +109,18 @@ export async function signCapabilityInvocation({
     signed['capability-invocation'] = invocationHeader;
 
     // options.body and options.json are not allowed at the same time.
-    // options.body was added after options.json, and may replace options.json in a future release.
-    if (body && json) throw new Error(`options.body and options.json MUST NOT be provided together`)
+    // options.body was added after options.json,
+    // and may replace options.json in a future release.
+    if(body && json) {
+      throw new Error(
+        `options.body and options.json MUST NOT be provided together`);
+    }
 
     // set body from options.json if options.body was not provided
-    if ( (!body) && json) {
+    if((!body) && json) {
       // assign body from json
-      body = new Blob([typeof json === 'string' ? json : JSON.stringify(json)],{type:'application/json'})
+      const jsonPart = typeof json === 'string' ? json : JSON.stringify(json);
+      body = new Blob([jsonPart], {type: 'application/json'});
     }
 
     if(body && signed.digest === undefined) {
@@ -121,7 +128,7 @@ export async function signCapabilityInvocation({
       signed.digest = await createHeaderValue({data: body, useMultihash: true});
 
       if(signed['content-type'] === undefined && body.type) {
-        signed['content-type'] = body.type
+        signed['content-type'] = body.type;
       }
     }
     // convert dates to unix time stamp
@@ -137,7 +144,7 @@ export async function signCapabilityInvocation({
       '(key-id)', '(created)', '(expires)', '(request-target)',
       'host', 'capability-invocation'];
     // if has a type, sign over content-type, otherwise don't.
-    if (body?.type) {
+    if(body?.type) {
       includeHeaders.push('content-type');
     }
     if(body) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@digitalbazaar/http-digest-header": "https://github.com/gobengo/http-digest-header.git#createHeaderValue_data_blob",
+    "@digitalbazaar/http-digest-header": "^2.1.0",
     "@digitalbazaar/http-signature-header": "^5.0.0",
     "base64url-universal": "^2.0.0",
     "pako": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@digitalbazaar/http-digest-header": "^2.0.0",
+    "@digitalbazaar/http-digest-header": "https://github.com/gobengo/http-digest-header.git#createHeaderValue_data_blob",
     "@digitalbazaar/http-signature-header": "^5.0.0",
     "base64url-universal": "^2.0.0",
     "pako": "^2.0.4"

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -199,6 +199,51 @@ describe('signCapabilityInvocation', function() {
           await verify({signed, Suite, keyPair});
         });
 
+        it('a valid root zCap with body typeless Blob', async function () {
+          const nonce1 = crypto.randomUUID()
+          const body1 = new Blob([nonce1])
+          // default options for signCapabilityInvocation
+          const invocationBase = {
+            url: TEST_URL,
+            method,
+            headers: {
+              date: new Date().toUTCString()
+            },
+            invocationSigner,
+            capabilityAction: 'read'
+          }
+          const signed = await signCapabilityInvocation({
+            ...invocationBase,
+            body: body1,
+          });
+
+          shouldBeAnAuthorizedRequest(signed);
+
+          should.equal(typeof signed.digest, 'string',
+            `signed headers should include Digest string`)
+
+          // no content-type because body1 has no .type
+          should.not.exist(signed['content-type']);
+          // the authorization header should not sign over content-type,
+          // because body1 has no .type
+          should.not.equal(signed.authorization.includes('content-type'), true)
+
+          await verify({ signed, Suite, keyPair });
+
+          // above could all pass if there is a bug in the common
+          // digest function used by both `signCapabilityInvocation` and `verify`.
+          // e.g. if digest function always just digests everything the same.
+          // ensure digests for different bodies are different.
+          const nonce2 = crypto.randomUUID()
+          const body2 = new Blob([nonce2])
+          const signedBody2 = await signCapabilityInvocation({
+            ...invocationBase,
+            body: body2,
+          });
+          should.not.equal(signed.digest, signedBody2.digest,
+            `digests differ when body buffers differ`)
+        });
+
         it('a valid root zCap with non-JSON body Blob', async function () {
           const nonce1 = crypto.randomUUID()
           const body1 = new Blob([nonce1], {type: `text/plain+${nonce1}`})

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -199,6 +199,44 @@ describe('signCapabilityInvocation', function() {
           await verify({signed, Suite, keyPair});
         });
 
+        it('a valid root zCap with non-JSON body Blob', async function () {
+          const nonce1 = crypto.randomUUID()
+          const body1 = new Blob([nonce1], {type: `text/plain+${nonce1}`})
+          /**
+           * @param {Blob} body
+           */
+          async function signBody(body) {
+            return await signCapabilityInvocation({
+              url: TEST_URL,
+              method,
+              headers: {
+                date: new Date().toUTCString()
+              },
+              body,
+              invocationSigner,
+              capabilityAction: 'read'
+            });
+          }
+          const signed = await signBody(body1)
+          shouldBeAnAuthorizedRequest(signed);
+          should.equal(typeof signed.digest, 'string',
+            `signed headers should include Digest string`)
+          should.exist(signed['content-type']);
+          signed['content-type'].should.be.a('string');
+          signed['content-type'].should.equal(body1.type);
+          await verify({ signed, Suite, keyPair });
+
+          // above could all pass if there is a bug in the common
+          // digest function used by both `signCapabilityInvocation` and `verify`.
+          // e.g. if digest function always just digests everything the same.
+          // ensure digests for different bodies are different.
+          const nonce2 = crypto.randomUUID()
+          const body2 = new Blob([nonce2], {type:body1.type})
+          const signedBody2 = await signBody(body2)
+          should.not.equal(signed.digest, signedBody2.digest,
+            `digests differ when body buffers differ`)
+        });
+
         it('a valid root zCap with json', async function() {
           const signed = await signCapabilityInvocation({
             url: TEST_URL,

--- a/tests/10-sign.spec.js
+++ b/tests/10-sign.spec.js
@@ -199,9 +199,9 @@ describe('signCapabilityInvocation', function() {
           await verify({signed, Suite, keyPair});
         });
 
-        it('a valid root zCap with body typeless Blob', async function () {
-          const nonce1 = crypto.randomUUID()
-          const body1 = new Blob([nonce1])
+        it('a valid root zCap with body typeless Blob', async function() {
+          const nonce1 = crypto.randomUUID();
+          const body1 = new Blob([nonce1]);
           // default options for signCapabilityInvocation
           const invocationBase = {
             url: TEST_URL,
@@ -211,7 +211,7 @@ describe('signCapabilityInvocation', function() {
             },
             invocationSigner,
             capabilityAction: 'read'
-          }
+          };
           const signed = await signCapabilityInvocation({
             ...invocationBase,
             body: body1,
@@ -220,38 +220,38 @@ describe('signCapabilityInvocation', function() {
           shouldBeAnAuthorizedRequest(signed);
 
           should.equal(typeof signed.digest, 'string',
-            `signed headers should include Digest string`)
+            `signed headers should include Digest string`);
 
           // no content-type because body1 has no .type
           should.not.exist(signed['content-type']);
           // the authorization header should not sign over content-type,
           // because body1 has no .type
-          should.not.equal(signed.authorization.includes('content-type'), true)
+          should.not.equal(signed.authorization.includes('content-type'), true);
 
-          await verify({ signed, Suite, keyPair });
+          await verify({signed, Suite, keyPair});
 
           // above could all pass if there is a bug in the common
-          // digest function used by both `signCapabilityInvocation` and `verify`.
+          // digest function used by `signCapabilityInvocation` and `verify`
           // e.g. if digest function always just digests everything the same.
           // ensure digests for different bodies are different.
-          const nonce2 = crypto.randomUUID()
-          const body2 = new Blob([nonce2])
+          const nonce2 = crypto.randomUUID();
+          const body2 = new Blob([nonce2]);
           const signedBody2 = await signCapabilityInvocation({
             ...invocationBase,
             body: body2,
           });
           should.not.equal(signed.digest, signedBody2.digest,
-            `digests differ when body buffers differ`)
+            `digests differ when body buffers differ`);
         });
 
-        it('a valid root zCap with non-JSON body Blob', async function () {
-          const nonce1 = crypto.randomUUID()
-          const body1 = new Blob([nonce1], {type: `text/plain+${nonce1}`})
+        it('a valid root zCap with non-JSON body Blob', async function() {
+          const nonce1 = crypto.randomUUID();
+          const body1 = new Blob([nonce1], {type: `text/plain+${nonce1}`});
           /**
-           * @param {Blob} body
+           * @param {Blob} body - Body of http request that should be signed.
            */
           async function signBody(body) {
-            return await signCapabilityInvocation({
+            return signCapabilityInvocation({
               url: TEST_URL,
               method,
               headers: {
@@ -262,24 +262,24 @@ describe('signCapabilityInvocation', function() {
               capabilityAction: 'read'
             });
           }
-          const signed = await signBody(body1)
+          const signed = await signBody(body1);
           shouldBeAnAuthorizedRequest(signed);
           should.equal(typeof signed.digest, 'string',
-            `signed headers should include Digest string`)
+            `signed headers should include Digest string`);
           should.exist(signed['content-type']);
           signed['content-type'].should.be.a('string');
           signed['content-type'].should.equal(body1.type);
-          await verify({ signed, Suite, keyPair });
+          await verify({signed, Suite, keyPair});
 
           // above could all pass if there is a bug in the common
-          // digest function used by both `signCapabilityInvocation` and `verify`.
+          // digest function used by `signCapabilityInvocation` and `verify`.
           // e.g. if digest function always just digests everything the same.
           // ensure digests for different bodies are different.
-          const nonce2 = crypto.randomUUID()
-          const body2 = new Blob([nonce2], {type:body1.type})
-          const signedBody2 = await signBody(body2)
+          const nonce2 = crypto.randomUUID();
+          const body2 = new Blob([nonce2], {type: body1.type});
+          const signedBody2 = await signBody(body2);
           should.not.equal(signed.digest, signedBody2.digest,
-            `digests differ when body buffers differ`)
+            `digests differ when body buffers differ`);
         });
 
         it('a valid root zCap with json', async function() {


### PR DESCRIPTION
Draft PR Because
* for the new test in this PR to pass, it needs the changes to http-digest-header I proposed here (and @dlongley indicates willingness to accept) https://github.com/digitalbazaar/http-digest-header/pull/14

To do
* [x] @dlongley @gobengo review or merge https://github.com/digitalbazaar/http-digest-header/pull/14
* [x] @dlongley release new version of @digitalbazaar/http-digest-header
* [x] @gobengo update this PR to use new release of @digitalbazaar/http-digest-header
* [x] @gobengo request review from @dlongley 
* [x] iterate toward merge based on feedback from @dlongley 